### PR TITLE
Improve logging with error handling and colored payloads

### DIFF
--- a/src/components/LogFeed.jsx
+++ b/src/components/LogFeed.jsx
@@ -1,5 +1,33 @@
 import React, { useEffect, useRef } from 'react';
 
+function LogEntry({ log }) {
+  const color = log.type === 'error' ? 'text-red-600' : 'text-blue-700';
+
+  let details = null;
+  if (log.payload) {
+    if ('x' in log.payload && 'y' in log.payload) {
+      details = (
+        <span className="ml-1 text-purple-600">
+          (X: {log.payload.x}, Y: {log.payload.y})
+        </span>
+      );
+    } else if ('held' in log.payload) {
+      details = (
+        <span className="ml-1 text-amber-600">held: {String(log.payload.held)}</span>
+      );
+    } else {
+      details = <span className="ml-1 text-gray-600">{JSON.stringify(log.payload)}</span>;
+    }
+  }
+
+  return (
+    <div className={`p-1 rounded ${color}`}>
+      {log.text}
+      {details}
+    </div>
+  );
+}
+
 export default function LogFeed({ logs }) {
   const containerRef = useRef(null);
   useEffect(() => {
@@ -12,14 +40,7 @@ export default function LogFeed({ logs }) {
       className="bg-white border rounded p-2 h-48 overflow-y-auto text-sm font-mono space-y-1"
     >
       {logs.map((log, idx) => (
-        <div
-          key={idx}
-          className={
-            'p-1 rounded ' + (log.type === 'error' ? 'text-red-600' : 'text-blue-700')
-          }
-        >
-          {log.text}
-        </div>
+        <LogEntry key={idx} log={log} />
       ))}
     </div>
   );

--- a/src/emitEvent.js
+++ b/src/emitEvent.js
@@ -1,14 +1,26 @@
-export default async function emitEvent({ eventType, payload, endpoint, emitType, wsRef, onLog }) {
+export default async function emitEvent({
+  eventType,
+  payload,
+  endpoint,
+  emitType,
+  wsRef,
+  onLog,
+}) {
   const message = { eventType, payload };
   console.log('Emit:', message, 'to', endpoint, 'via', emitType);
-  if (onLog) {
-    onLog({
-      type: 'info',
-      text: `Sending ${eventType} via ${emitType} to ${endpoint} ${JSON.stringify(payload)}`,
-    });
-  }
 
-  if (!endpoint) return;
+  // initial log
+  onLog?.({
+    type: 'info',
+    text: `Sending ${eventType} via ${emitType} to ${endpoint}`,
+    eventType,
+    payload,
+  });
+
+  if (!endpoint) {
+    onLog?.({ type: 'error', text: 'No endpoint specified', eventType, payload });
+    return;
+  }
 
   if (emitType === 'websocket') {
     // Reuse or create WebSocket
@@ -17,47 +29,71 @@ export default async function emitEvent({ eventType, payload, endpoint, emitType
       wsRef.current = new window.WebSocket(endpoint);
       wsRef.current.onopen = () => {
         wsRef.current.send(JSON.stringify(message));
-        onLog &&
-          onLog({
-            type: 'info',
-            text: `WebSocket sent ${JSON.stringify(message)}`,
-          });
+        onLog?.({
+          type: 'info',
+          text: `WebSocket sent ${JSON.stringify(message)}`,
+          eventType,
+          payload,
+        });
       };
       wsRef.current.onerror = err => {
         console.warn('WebSocket error:', err);
-        onLog &&
-          onLog({
+        onLog?.({
+          type: 'error',
+          text: `WebSocket error: ${err.message || err}`,
+          eventType,
+          payload,
+        });
+      };
+      wsRef.current.onclose = evt => {
+        if (evt.code !== 1000) {
+          onLog?.({
             type: 'error',
-            text: `WebSocket error: ${err.message || err}`,
+            text: `WebSocket closed code ${evt.code}`,
+            eventType,
+            payload,
           });
+        }
       };
     } else if (wsRef.current.readyState === 1) {
       wsRef.current.send(JSON.stringify(message));
-      onLog &&
-        onLog({
-          type: 'info',
-          text: `WebSocket sent ${JSON.stringify(message)}`,
-        });
+      onLog?.({
+        type: 'info',
+        text: `WebSocket sent ${JSON.stringify(message)}`,
+        eventType,
+        payload,
+      });
     }
   } else if (emitType === 'http') {
     try {
-      await fetch(endpoint, {
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(message),
       });
-      onLog &&
-        onLog({
+      if (!res.ok) {
+        onLog?.({
+          type: 'error',
+          text: `HTTP error ${res.status}`,
+          eventType,
+          payload,
+        });
+      } else {
+        onLog?.({
           type: 'info',
           text: `HTTP POST sent ${JSON.stringify(message)}`,
+          eventType,
+          payload,
         });
+      }
     } catch (e) {
       console.warn('HTTP POST error:', e);
-      onLog &&
-        onLog({
-          type: 'error',
-          text: `HTTP POST error: ${e.message || e}`,
-        });
+      onLog?.({
+        type: 'error',
+        text: `HTTP POST error: ${e.message || e}`,
+        eventType,
+        payload,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- refine emitEvent logging by including event payload, providing missing-endpoint errors, handling WebSocket close/errors and HTTP response codes
- color code payload fields in LogFeed (coordinates, held state)

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856072b0b148332af34c2665c2711cf