### PR TITLE
Add publish date display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,12 @@ export default function App() {
       <ButtonEvent emitEvent={handleEmitEvent} />
       <MiniMap emitEvent={handleEmitEvent} />
       <LogFeed logs={logs} />
+      <p className="text-center text-xs text-gray-500">
+        Last published:{' '}
+        {import.meta.env.PUBLISH_DATETIME
+          ? new Date(import.meta.env.PUBLISH_DATETIME).toLocaleString()
+          : 'Unknown'}
+      </p>
     </div>
   );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,4 +7,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
   },
-}); 
+  define: {
+    'import.meta.env.PUBLISH_DATETIME': JSON.stringify(new Date().toISOString()),
+  },
+});


### PR DESCRIPTION
## Summary
- define build-time constant `PUBLISH_DATETIME`
- show publish date in the app footer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856076fe21c83328bda72698c7fe297