### PR TITLE
Add default endpoints for WebSocket and HTTP

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,38 @@
-import React, { useState, useRef } from 'react';
-import EndpointConfig from './components/EndpointConfig';
-import ButtonEvent from './components/ButtonEvent';
-import MiniMap from './components/MiniMap';
-import LogFeed from './components/LogFeed';
-import emitEvent from './emitEvent';
+import React, { useState, useRef } from "react";
+import EndpointConfig from "./components/EndpointConfig";
+import ButtonEvent from "./components/ButtonEvent";
+import MiniMap from "./components/MiniMap";
+import LogFeed from "./components/LogFeed";
+import emitEvent from "./emitEvent";
+
+const DEFAULT_WS = "ws://192.168.1.42:3000/ws";
+const DEFAULT_HTTP = "https://staging.forgedsports.link/api/events/create/";
 
 export default function App() {
-  const [endpoint, setEndpoint] = useState('');
-  const [emitType, setEmitType] = useState('websocket'); // or 'http'
+  const [emitType, setEmitType] = useState("websocket");
+  const [wsEndpoint, setWsEndpoint] = useState(DEFAULT_WS);
+  const [httpEndpoint, setHttpEndpoint] = useState(DEFAULT_HTTP);
   const wsRef = useRef(null);
   const [logs, setLogs] = useState([]);
 
-  const addLog = log => setLogs(l => [log, ...l]);
+  const addLog = (log) => setLogs((l) => [log, ...l]);
+
+  const currentEndpoint = emitType === "websocket" ? wsEndpoint : httpEndpoint;
+
+  const setCurrentEndpoint = (value) => {
+    if (emitType === "websocket") {
+      setWsEndpoint(value);
+    } else {
+      setHttpEndpoint(value);
+    }
+  };
 
   // Pass emitEvent with endpoint/type/wsRef
   const handleEmitEvent = (type, payload) => {
     emitEvent({
       eventType: type,
       payload,
-      endpoint,
+      endpoint: currentEndpoint,
       emitType,
       wsRef,
       onLog: addLog,
@@ -29,8 +43,8 @@ export default function App() {
     <div className="max-w-2xl mx-auto p-4 flex flex-col gap-6">
       <h1 className="text-2xl font-bold text-center mb-2">Emitter UI</h1>
       <EndpointConfig
-        endpoint={endpoint}
-        setEndpoint={setEndpoint}
+        endpoint={currentEndpoint}
+        setEndpoint={setCurrentEndpoint}
         emitType={emitType}
         setEmitType={setEmitType}
       />

--- a/src/components/EndpointConfig.jsx
+++ b/src/components/EndpointConfig.jsx
@@ -1,23 +1,32 @@
-import React from 'react';
+import React from "react";
 
-export default function EndpointConfig({ endpoint, setEndpoint, emitType, setEmitType }) {
+export default function EndpointConfig({
+  endpoint,
+  setEndpoint,
+  emitType,
+  setEmitType,
+}) {
+  const placeholder =
+    emitType === "websocket"
+      ? "ws://192.168.1.42:3000/ws"
+      : "https://staging.forgedsports.link/api/events/create/";
   return (
     <div className="flex flex-col sm:flex-row items-center gap-3">
       <input
         type="text"
         className="flex-1 border rounded px-3 py-2 text-sm"
-        placeholder="Endpoint URL (e.g. ws://localhost:8080 or https://api.example.com)"
+        placeholder={placeholder}
         value={endpoint}
-        onChange={e => setEndpoint(e.target.value)}
+        onChange={(e) => setEndpoint(e.target.value)}
       />
       <select
         className="border rounded px-2 py-2 text-sm"
         value={emitType}
-        onChange={e => setEmitType(e.target.value)}
+        onChange={(e) => setEmitType(e.target.value)}
       >
         <option value="websocket">WebSocket</option>
         <option value="http">HTTP POST</option>
       </select>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- preset API endpoints in the React emitter based on the Unity mods
- keep separate HTTP and WebSocket endpoints
- show appropriate default placeholder in EndpointConfig

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685602439d388332a10c7ad1abd57cc4