### PR TITLE
Fix GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Deploy
         run: npm run deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm run dev
 2. Deploy the contents of the `dist/` folder to your GitHub Pages branch (usually `gh-pages`).
 
    - If you haven't set up GitHub Pages yet, go to your repository settings, scroll down to the "GitHub Pages" section, and select the branch you want to deploy (e.g., `gh-pages`).
+   - When using GitHub Actions, make sure the workflow exports `GH_TOKEN` from `secrets.GITHUB_TOKEN` so the `gh-pages` CLI can authenticate.
 
 3. Your app will be available at `https://<your-username>.github.io/<your-repo-name>/`.
 


### PR DESCRIPTION
## Summary
- fix GH auth token in deploy workflow
- document GH_TOKEN usage in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68560da9260c8332b99fc36facc4b018