### PR TITLE
Improve WebSocket error logging

### DIFF
--- a/src/components/LogFeed.jsx
+++ b/src/components/LogFeed.jsx
@@ -21,7 +21,7 @@ function LogEntry({ log }) {
   }
 
   return (
-    <div className={`p-1 rounded ${color}`}>
+    <div className={`p-1 rounded ${color} whitespace-pre-wrap`}>
       {log.text}
       {details}
     </div>

--- a/src/emitEvent.js
+++ b/src/emitEvent.js
@@ -38,9 +38,15 @@ export default async function emitEvent({
       };
       wsRef.current.onerror = err => {
         console.warn('WebSocket error:', err);
+        let errDetails = '';
+        try {
+          errDetails = JSON.stringify(err, Object.getOwnPropertyNames(err));
+        } catch (e) {
+          errDetails = String(err);
+        }
         onLog?.({
           type: 'error',
-          text: `WebSocket error: ${err.message || err}`,
+          text: `WebSocket error at ${endpoint} sending ${JSON.stringify(message)}: ${err.message || err.type || ''}\nEvent: ${errDetails}`,
           eventType,
           payload,
         });


### PR DESCRIPTION
## Summary
- log websocket errors with endpoint, message payload and event details
- show logs preserving newlines for better readability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859aaf43dd083328d9c694e3b33895b