### PR TITLE
Add emoji selection feature

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,18 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emitter-golf-codex",
   "version": "1.0.0",
   "private": true,
-  "homepage": "./",
+  "homepage": "https://forgedsports.github.io/emitterGolf_Codex",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ export default function App() {
   const [httpEndpoint, setHttpEndpoint] = useState(DEFAULT_HTTP);
   const wsRef = useRef(null);
   const [logs, setLogs] = useState([]);
+  const [selectedEmoji, setSelectedEmoji] = useState(null);
 
   const addLog = (log) => setLogs((l) => [log, ...l]);
 
@@ -30,9 +31,15 @@ export default function App() {
 
   // Pass emitEvent with endpoint/type/wsRef
   const handleEmitEvent = (type, payload) => {
+    // Add emoji to all payloads
+    const payloadWithEmoji = {
+      ...payload,
+      emote: selectedEmoji || 'none'
+    };
+    
     emitEvent({
       eventType: type,
-      payload,
+      payload: payloadWithEmoji,
       endpoint: currentEndpoint,
       emitType,
       wsRef,
@@ -50,7 +57,7 @@ export default function App() {
         setEmitType={setEmitType}
       />
       <ButtonEvent emitEvent={handleEmitEvent} />
-      <EmojiSelector emitEvent={handleEmitEvent} />
+      <EmojiSelector selectedEmoji={selectedEmoji} onEmojiSelect={setSelectedEmoji} />
       <MiniMap emitEvent={handleEmitEvent} />
       <LogFeed logs={logs} />
       <p className="text-center text-xs text-gray-500">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import EndpointConfig from "./components/EndpointConfig";
 import ButtonEvent from "./components/ButtonEvent";
 import MiniMap from "./components/MiniMap";
 import LogFeed from "./components/LogFeed";
+import EmojiSelector from "./components/EmojiSelector";
 import emitEvent from "./emitEvent";
 
 const DEFAULT_WS = "wss://birdieboosters-production.up.railway.app";
@@ -49,6 +50,7 @@ export default function App() {
         setEmitType={setEmitType}
       />
       <ButtonEvent emitEvent={handleEmitEvent} />
+      <EmojiSelector emitEvent={handleEmitEvent} />
       <MiniMap emitEvent={handleEmitEvent} />
       <LogFeed logs={logs} />
       <p className="text-center text-xs text-gray-500">

--- a/src/components/EmojiSelector.jsx
+++ b/src/components/EmojiSelector.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+const EMOJIS = [
+  { emoji: '💩', value: 'poop' },
+  { emoji: '😃', value: 'smiley' },
+  { emoji: '🔥', value: 'fire' },
+  { emoji: '❤️', value: 'heart' }
+];
+
+export default function EmojiSelector({ emitEvent }) {
+  const [selectedEmoji, setSelectedEmoji] = useState(null);
+
+  const handleEmojiClick = (emojiData) => {
+    if (selectedEmoji === emojiData.value) {
+      // Unselect if clicking the same emoji
+      setSelectedEmoji(null);
+      emitEvent('emote', 'none');
+    } else {
+      // Select new emoji
+      setSelectedEmoji(emojiData.value);
+      emitEvent('emote', emojiData.value);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4">
+      <h3 className="text-lg font-semibold mb-3 text-gray-800">Emoji Reaction</h3>
+      <div className="flex justify-center gap-4">
+        {EMOJIS.map((emojiData) => (
+          <button
+            key={emojiData.value}
+            onClick={() => handleEmojiClick(emojiData)}
+            className={`
+              text-3xl p-3 rounded-full transition-all duration-200 transform hover:scale-110
+              ${selectedEmoji === emojiData.value 
+                ? 'bg-blue-100 ring-2 ring-blue-400 shadow-lg' 
+                : 'bg-gray-50 hover:bg-gray-100'
+              }
+            `}
+            title={`Select ${emojiData.value} emoji`}
+          >
+            {emojiData.emoji}
+          </button>
+        ))}
+      </div>
+      {selectedEmoji && (
+        <p className="text-center text-sm text-gray-600 mt-2">
+          Selected: {selectedEmoji}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/EmojiSelector.jsx
+++ b/src/components/EmojiSelector.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 const EMOJIS = [
   { emoji: '💩', value: 'poop' },
@@ -7,18 +7,14 @@ const EMOJIS = [
   { emoji: '❤️', value: 'heart' }
 ];
 
-export default function EmojiSelector({ emitEvent }) {
-  const [selectedEmoji, setSelectedEmoji] = useState(null);
-
+export default function EmojiSelector({ selectedEmoji, onEmojiSelect }) {
   const handleEmojiClick = (emojiData) => {
     if (selectedEmoji === emojiData.value) {
       // Unselect if clicking the same emoji
-      setSelectedEmoji(null);
-      emitEvent('emote', 'none');
+      onEmojiSelect(null);
     } else {
       // Select new emoji
-      setSelectedEmoji(emojiData.value);
-      emitEvent('emote', emojiData.value);
+      onEmojiSelect(emojiData.value);
     }
   };
 


### PR DESCRIPTION
Add an emoji selector that includes the chosen emoji in all existing event payloads, and fix GitHub Pages deployment.

The emoji selection is designed to enrich existing event payloads (e.g., button presses, XY updates) with the user's current emoji choice, rather than sending a separate 'emote' event on selection. This aligns with the requirement to include the selected emoji with all current interaction data.